### PR TITLE
+Kill orphaned downloads, +various small tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Logs everything and streams the info. You can replace with good ol' print if you
 This script was created to work in a docker container so the included files are necessary.
 to use in a docker container, copy folder to the machine hosting your docker, `CD` into the directory where the files are located and enter these following 2 commands:
 
-1# `docker build -t media-cleaner .`
+1# `docker build -t sonarr-radarr-queue-cleaner .`
 
-2#. `docker run -d --name media-cleaner -e SONARR_API_KEY='123456' -e RADARR_API_KEY='123456' -e SONARR_URL='http://sonarr:8989' -e RADARR_URL='http://radarr:7878' -e API_TIMEOUT='600' media-cleaner`
+2#. `docker run -d --name sonarr-radarr-queue-cleaner -e SONARR_API_KEY='123456' -e RADARR_API_KEY='123456' -e SONARR_URL='http://sonarr:8989' -e RADARR_URL='http://radarr:7878' -e TIMEOUT='600' --network="myDockerNetwork" sonarr-radarr-queue-cleaner`

--- a/cleaner.py
+++ b/cleaner.py
@@ -1,13 +1,19 @@
 # Simple Sonarr and Radarr script created by Matt (MattDGTL) Pomales to clean out stalled downloads.
 # Coulnd't find a python script to do this job so I figured why not give it a try.
+# 
+# Purpose of script: 
+# Removes stale and orphan downloads from Sonarr/Radarr
 
+########### Import Libraries
 import os
 import asyncio
 import logging
 import requests
 from requests.exceptions import RequestException
 import json
+from dateutil.relativedelta import relativedelta as rd
 
+########### Enabling Logging
 # Set up logging
 logging.basicConfig(
     format='%(asctime)s [%(levelname)s]: %(message)s', 
@@ -15,6 +21,7 @@ logging.basicConfig(
     handlers=[logging.StreamHandler()]
 )
 
+########### Loading Parameters
 # Sonarr and Radarr API endpoints
 SONARR_API_URL = (os.environ['SONARR_URL']) + "/api/v3"
 RADARR_API_URL = (os.environ['RADARR_URL']) + "/api/v3"
@@ -24,8 +31,9 @@ SONARR_API_KEY = (os.environ['SONARR_API_KEY'])
 RADARR_API_KEY = (os.environ['RADARR_API_KEY'])
 
 # Timeout for API requests in seconds
-API_TIMEOUT = int(os.environ['API_TIMEOUT']) # 10 minutes
+API_TIMEOUT = int(os.environ['TIMEOUT']) # 10 minutes
 
+########### Shared Functions
 # Function to make API requests with error handling
 async def make_api_request(url, api_key, params=None):
     try:
@@ -40,12 +48,21 @@ async def make_api_request(url, api_key, params=None):
         logging.error(f'Error parsing JSON response from {url}: {e}')
         return None
 
+# Make a request to view and count items in queue and return the number.
+async def count_records(API_URL, API_Key, GetParams=''):
+    the_url = f'{API_URL}/queue?' + GetParams
+    the_queue = await make_api_request(the_url, API_Key)
+    if the_queue is not None and 'records' in the_queue:
+        return the_queue['totalRecords']
+
 # Function to make API delete with error handling
 async def make_api_delete(url, api_key, params=None):
     try:
         headers = {'X-Api-Key': api_key}
         response = await asyncio.get_event_loop().run_in_executor(None, lambda: requests.delete(url, params=params, headers=headers))
-        response.raise_for_status()
+        response.raise_for_status()        
+        if response.status_code == 200: 
+            return None
         return response.json()
     except RequestException as e:
         logging.error(f'Error making API request to {url}: {e}')
@@ -53,59 +70,128 @@ async def make_api_delete(url, api_key, params=None):
     except ValueError as e:
         logging.error(f'Error parsing JSON response from {url}: {e}')
         return None
-    
+
+########### STALE Downloads
+### Stale downloads are those that are still in progress, but are not continuing as they are stuck (stale)
+### Script will kill those downloads, and ban the trackers
+
 # Function to remove stalled Sonarr downloads
 async def remove_stalled_sonarr_downloads():
-    logging.info('Checking Sonarr queue...')
+    logging.info('> Checking Sonarr queue for stalled downloads...')
     sonarr_url = f'{SONARR_API_URL}/queue'
     sonarr_queue = await make_api_request(sonarr_url, SONARR_API_KEY, {'page': '1', 'pageSize': await count_records(SONARR_API_URL,SONARR_API_KEY)})
     if sonarr_queue is not None and 'records' in sonarr_queue:
-        logging.info('Processing Sonarr queue...')
+        # logging.info('Processing Sonarr queue for stalled downloads...')
+        stalled_count = 0
         for item in sonarr_queue['records']:
             if 'title' in item and 'status' in item and 'trackedDownloadStatus' in item:
-                logging.info(f'Checking the status of {item["title"]}')
+                # logging.info(f'>>> > Checking the status of {item["title"]}')
                 if item['status'] == 'warning' and item['errorMessage'] == 'The download is stalled with no connections':
                     logging.info(f'Removing stalled Sonarr download: {item["title"]}')
+                    stalled_count += 1
                     await make_api_delete(f'{SONARR_API_URL}/queue/{item["id"]}', SONARR_API_KEY, {'removeFromClient': 'true', 'blocklist': 'true'})
             else:
                 logging.warning('Skipping item in Sonarr queue due to missing or invalid keys')
+        if stalled_count == 0:
+            logging.info('>>> No Sonarr stalled downloads found.')
     else:
         logging.warning('Sonarr queue is None or missing "records" key')
 
 # Function to remove stalled Radarr downloads
 async def remove_stalled_radarr_downloads():
-    logging.info('Checking radarr queue...')
+    logging.info('> Checking Radarr queue for stalled downloads...')
     radarr_url = f'{RADARR_API_URL}/queue'
     radarr_queue = await make_api_request(radarr_url, RADARR_API_KEY, {'page': '1', 'pageSize': await count_records(RADARR_API_URL,RADARR_API_KEY)})
     if radarr_queue is not None and 'records' in radarr_queue:
-        logging.info('Processing Radarr queue...')
+        # logging.info('Processing Radarr queue for stalled downloads...')
+        stalled_count = 0
         for item in radarr_queue['records']:
             if 'title' in item and 'status' in item and 'trackedDownloadStatus' in item:
-                logging.info(f'Checking the status of {item["title"]}')
+                # logging.info(f'>>> > Checking the status of {item["title"]}')
                 if item['status'] == 'warning' and item['errorMessage'] == 'The download is stalled with no connections':
                     logging.info(f'Removing stalled Radarr download: {item["title"]}')
+                    stalled_count += 1
                     await make_api_delete(f'{RADARR_API_URL}/queue/{item["id"]}', RADARR_API_KEY, {'removeFromClient': 'true', 'blocklist': 'true'})
             else:
-                logging.warning('Skipping item in Radarr queue due to missing or invalid keys')
+                ogging.warning('Skipping item in Radarr queue due to missing or invalid keys')
+        if stalled_count == 0:
+            logging.info('>>> No Sonarr stalled downloads found.')
     else:
         logging.warning('Radarr queue is None or missing "records" key')
 
-# Make a request to view and count items in queue and return the number.
-async def count_records(API_URL, API_Key):
-    the_url = f'{API_URL}/queue'
-    the_queue = await make_api_request(the_url, API_Key)
-    if the_queue is not None and 'records' in the_queue:
-        return the_queue['totalRecords']
+########### ORPHAN Downloads
+### Orphan downloads are those that are still in progress, but not linked to a TV Show / Movie anymore 
+### This occurs when a Download is initiated and still in progress, and in the meantime the TV Show / Movie is deleted from Radarr/Sonarr
+### Script will kill those downloads but not ban them (for future downloads, if needed)
+
+# Function to remove Sonarr queue items linked to no movies (orphan downloads)
+async def remove_orphan_sonarr_downloads():
+    logging.info('> Checking Sonarr queue for orphan downloads...')
+    sonarr_url = f'{SONARR_API_URL}/queue'
+    sonarr_queue = await make_api_request(sonarr_url, SONARR_API_KEY, {'page': '1', 'pageSize': await count_records(SONARR_API_URL,SONARR_API_KEY)})
+    sonarr_url = f'{SONARR_API_URL}/queue?includeUnknownSeriesItems=true'
+    sonarr_queue_incl_unknown = await make_api_request(sonarr_url, SONARR_API_KEY, {'page': '1', 'pageSize': await count_records(SONARR_API_URL,SONARR_API_KEY,'includeUnknownSeriesItems=true')})
+    if sonarr_queue_incl_unknown is not None and 'records' in sonarr_queue_incl_unknown:
+        Full_list = {}
+        OK_list = {}
+        for item in sonarr_queue_incl_unknown['records']:
+            Full_list[item['id']] = item['title']
+        if sonarr_queue is not None and 'records' in sonarr_queue:
+            for item in sonarr_queue['records']:
+                OK_list[item['id']] = item['title']
+        else:
+            logging.warning('Sonarr queue linked to movies is  None or missing "records" key')
+        orphan_downloads = {id: Full_list[id] for id in Full_list if id not in OK_list}
+        if len(orphan_downloads) == 0:
+            logging.info('>>> No Sonarr orphan downloads found.')
+        else:
+            for id in orphan_downloads:
+                logging.info(f'Removing orphan Sonarr download: {orphan_downloads[id]}')
+                await make_api_delete(f'{SONARR_API_URL}/queue/{id}', SONARR_API_KEY, {'removeFromClient': 'true', 'blocklist': 'false'})
+    else:
+        logging.warning('Sonarr queue is None or missing "records" key')
+
+# Function to remove Radarr queue items linked to no movies (orphan downloads)
+async def remove_orphan_radarr_downloads():
+    logging.info('> Checking Radarr queue for orphan downloads...')
+    radarr_url = f'{RADARR_API_URL}/queue'
+    radarr_queue = await make_api_request(radarr_url, RADARR_API_KEY, {'page': '1', 'pageSize': await count_records(RADARR_API_URL,RADARR_API_KEY)})
+    radarr_url = f'{RADARR_API_URL}/queue?includeUnknownMovieItems=true'
+    radarr_queue_incl_unknown = await make_api_request(radarr_url, RADARR_API_KEY, {'page': '1', 'pageSize': await count_records(RADARR_API_URL,RADARR_API_KEY,'includeUnknownMovieItems=true')})
+    if radarr_queue_incl_unknown is not None and 'records' in radarr_queue_incl_unknown:
+        Full_list = {}
+        OK_list = {}
+        for item in radarr_queue_incl_unknown['records']:
+            Full_list[item['id']] = item['title']
+        if radarr_queue is not None and 'records' in radarr_queue:
+            for item in radarr_queue['records']:
+                OK_list[item['id']] = item['title']
+        else:
+            logging.warning('Radarr queue linked to movies is  None or missing "records" key')
+        orphan_downloads = {id: Full_list[id] for id in Full_list if id not in OK_list}
+        if len(orphan_downloads) == 0:
+            logging.info('>>> No Radarr orphan downloads found.')
+        else:
+            for id in orphan_downloads:
+                logging.info(f'Removing orphan Radarr download: {orphan_downloads[id]}')
+                await make_api_delete(f'{RADARR_API_URL}/queue/{id}', RADARR_API_KEY, {'removeFromClient': 'true', 'blocklist': 'false'})
+    else:
+        logging.warning('Radarr queue is None or missing "records" key')
+        
 
 # Main function
 async def main():
     while True:
-        logging.info('Running media-tools script')
+        logging.info('*******************************************************************************************************************')
+        logging.info('Running queue cleaner for Radarr/Sonarr.')
         await remove_stalled_sonarr_downloads()
         await remove_stalled_radarr_downloads()
-        logging.info('Finished running media-tools script. Sleeping for 10 minutes.')
+        await remove_orphan_radarr_downloads()
+        await remove_orphan_sonarr_downloads()
+        fmt = '{0.days} days {0.hours} hours {0.minutes} minutes {0.seconds} seconds'
+        logging.info(f'Finished running queue cleaner for Radarr/Sonarr. Sleeping for {fmt.format(rd(seconds=API_TIMEOUT))}.')
         await asyncio.sleep(API_TIMEOUT)
 
+
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 aiohttp
 asyncio
+python-dateutil


### PR DESCRIPTION
My first PR ever... :)

Added functionality to kill orphaned downloads (downloads initiated by Movies/TV Shows that were deleted whilst download is in progress)

Added few refinements:
- dealing with OK status code (200)) in make_api_delete
- better format for time wait
- change how asynchio is called (previous approach was deprecated)
- specified in ReadMe how to include the network in which this tool has to be called so that it can communicate with Sonarr/Radarr
- made logging a bit more easy to read
- fixed inconsistency in variable (API_TIMEOUT)
